### PR TITLE
Assign ['appium'] to config.services instead reading it

### DIFF
--- a/config/wdio.ios.conf.js
+++ b/config/wdio.ios.conf.js
@@ -34,6 +34,6 @@ config.capabilities = [
 // Services take over a specific job you don't want to take care of. They enhance
 // your test setup with almost no effort. Unlike plugins, they don't add new
 // commands. Instead, they hook themselves up into the test process.
-config.services['appium'];
+config.services = ['appium'];
 
 exports.config = config;


### PR DESCRIPTION
This causes the error TypeError: Cannot read property 'appium' of undefined